### PR TITLE
fix(docs): subtitle offset

### DIFF
--- a/assets/sass/docs.scss
+++ b/assets/sass/docs.scss
@@ -193,8 +193,8 @@ main {
 
   &::before {
     content: '';
-    height: 5rem;
-    margin-top: -5rem;
+    height: 7rem;
+    margin-top: -7rem;
     display: block;
   }
 


### PR DESCRIPTION
## Description

Top offset of the `<h2>` tags was broken with the new topbar.

## How Has This Been Tested?

Clicked on the # logos near the titles.

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix / Typo fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change respects the responsive layout of the website.
- [ ] I opened another pull request on another docs version to apply the same change. (Mentioned pull request if checked : #...)
